### PR TITLE
[FEAUTRE] - 회원가입 화면 및 로직 수정

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-01-29T14:05:51.633074800Z">
+        <DropdownSelection timestamp="2025-01-30T12:39:11.154540100Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CN302TMEB" />

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-01-27T10:58:10.713519300Z">
+        <DropdownSelection timestamp="2025-01-28T11:04:36.799494300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\mj010\.android\avd\my_Phone_API_34.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CN302TMEB" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-01-28T11:04:36.799494300Z">
+        <DropdownSelection timestamp="2025-01-29T14:05:51.633074800Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CN302TMEB" />

--- a/app/src/main/java/com/example/issuetalk/core/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/di/RepositoryModule.kt
@@ -1,0 +1,22 @@
+package com.example.issuetalk.core.data.di
+
+import com.example.issuetalk.core.data.repository.auth.AuthRepositoryImpl
+import com.example.issuetalk.core.domain.repository.auth.AuthRepository
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+interface RepositoryModule {
+    @Binds
+    @Singleton
+    fun bindsAuthRepository(
+        authRepositoryImpl : AuthRepositoryImpl
+    ) : AuthRepository
+
+
+}

--- a/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepository.kt
@@ -1,2 +1,0 @@
-package com.example.issuetalk.core.data.repository.auth
-

--- a/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
@@ -1,0 +1,19 @@
+package com.example.issuetalk.core.data.repository.auth
+
+import com.example.issuetalk.core.domain.repository.auth.AuthRepository
+import com.example.issuetalk.core.network.source.auth.AuthDataSource
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val authDataSource: AuthDataSource
+) : AuthRepository {
+    override suspend fun loginFirebase(email: String, password: String): Result<Unit> =
+        authDataSource.loginFirebase(email, password)
+
+    override suspend fun signUpFirebase(
+        email: String,
+        password: String,
+        name: String
+    ): Result<Unit> = authDataSource.signUpFirebase(email, password, name)
+
+}

--- a/app/src/main/java/com/example/issuetalk/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/example/issuetalk/core/designsystem/theme/Color.kt
@@ -2,14 +2,7 @@ package com.example.issuetalk.core.designsystem.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
-
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
-
+val lightRed = Color(0xBCE70C0C)
 val subColor = Color(0xFF15662B)
 val primaryColor = Color(0xFF1C6755)
 val searchFieldColor = Color(0x1B010C01)

--- a/app/src/main/java/com/example/issuetalk/core/designsystem/theme/Color.kt
+++ b/app/src/main/java/com/example/issuetalk/core/designsystem/theme/Color.kt
@@ -5,4 +5,5 @@ import androidx.compose.ui.graphics.Color
 val lightRed = Color(0xBCE70C0C)
 val subColor = Color(0xFF15662B)
 val primaryColor = Color(0xFF1C6755)
+val topBarColor = Color(0x8A309333)
 val searchFieldColor = Color(0x1B010C01)

--- a/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
@@ -1,0 +1,6 @@
+package com.example.issuetalk.core.domain.repository.auth
+
+interface AuthRepository {
+    suspend fun loginFirebase(email: String, password: String) : Result<Unit>
+    suspend fun signUpFirebase(email: String, password: String, name: String) : Result<Unit>
+}

--- a/app/src/main/java/com/example/issuetalk/core/network/di/FirebaseModule.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/di/FirebaseModule.kt
@@ -1,0 +1,30 @@
+package com.example.issuetalk.core.network.di
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseModule {
+
+    @Provides
+    @Singleton
+    fun providesFirebaseAuth() : FirebaseAuth {
+        return Firebase.auth
+    }
+
+    @Provides
+    @Singleton
+    fun providesFirebaseStore(): FirebaseFirestore {
+        return Firebase.firestore
+    }
+
+}

--- a/app/src/main/java/com/example/issuetalk/core/network/model/Subject.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/model/Subject.kt
@@ -14,5 +14,4 @@ data class Subject(
     val subjectField : String = "",
     val date : String = " ",
     val timestamp : Timestamp = Timestamp.now()
-
 )

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -2,6 +2,7 @@ package com.example.issuetalk.core.network.source.auth
 
 import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.userProfileChangeRequest
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -15,7 +16,12 @@ class AuthDataSource @Inject constructor(
         ).await()
     }
 
-    suspend fun signUpFirebase(email: String, password: String, name : String) : Result<Unit> = runCatching {
-
-    }
+    suspend fun signUpFirebase(email: String, password: String, name: String): Result<Unit> = runCatching {
+        firebaseAuth.createUserWithEmailAndPassword(email, password).await()
+            val user = firebaseAuth.currentUser
+            val profileUpdates = userProfileChangeRequest {
+                displayName = name
+            }
+            user!!.updateProfile(profileUpdates).await()
+        }
 }

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -1,0 +1,21 @@
+package com.example.issuetalk.core.network.source.auth
+
+import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class AuthDataSource @Inject constructor(
+    private val firebaseAuth: FirebaseAuth
+) {
+    suspend fun loginFirebase(email: String, password: String): Result<Unit> = runCatching {
+        firebaseAuth.signInWithEmailAndPassword(
+            email,
+            password
+        ).await()
+    }
+
+    suspend fun signUpFirebase(email: String, password: String, name : String) : Result<Unit> = runCatching {
+
+    }
+}

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -64,7 +65,7 @@ import com.example.issuetalk.core.designsystem.theme.subColor
 fun LoginRoute(
     navigateToHome: () -> Unit,
     navigateToSignUp: () -> Unit,
-    viewModel: LoginViewModel = viewModel()
+    viewModel: LoginViewModel = hiltViewModel()
 ) {
     val emailText by viewModel.emailText.collectAsStateWithLifecycle()
     val passwordText by viewModel.passwordText.collectAsStateWithLifecycle()
@@ -85,7 +86,7 @@ fun LoginRoute(
         passwordText,
         onEmailTextChanged = viewModel::setEmailText,
         onPasswordTextChanged = viewModel::setPasswordText,
-        login = viewModel::login,
+        loginFireabase = viewModel::loginFirebase,
         navigateToSignUp = viewModel::navigateToSignUp,
         navigateToHome = viewModel::navigateToHome
     )
@@ -104,7 +105,7 @@ fun LoginScreen(
     passwordText: String,
     onEmailTextChanged: (String) -> Unit,
     onPasswordTextChanged: (String) -> Unit,
-    login: () -> Unit,
+    loginFireabase: () -> Unit,
     navigateToSignUp: () -> Unit,
     navigateToHome: () -> Unit,
 ) {
@@ -140,6 +141,7 @@ fun LoginScreen(
             value = emailText,
             onValueChange = { onEmailTextChanged(it) },
             textStyle = TextStyle(fontSize = 14.sp),
+            maxLines = 1,
             placeholder = { Text("이메일", style = TextStyle(fontSize = 14.sp)) },
             trailingIcon = {
                 Icon(
@@ -186,7 +188,7 @@ fun LoginScreen(
                 keyboardType = KeyboardType.Password,
                 imeAction = ImeAction.Done
             ),
-            keyboardActions = KeyboardActions(onDone = { login() }),
+            keyboardActions = KeyboardActions(onDone = { loginFireabase() }),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 34.dp)
@@ -220,7 +222,7 @@ fun LoginScreen(
 
         Spacer(modifier = Modifier.height(20.dp))
         Button(
-            onClick = login,
+            onClick = loginFireabase,
             colors = ButtonDefaults.buttonColors(primaryColor),
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -2,6 +2,7 @@ package com.example.issuetalk.feature.auth
 
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -52,7 +53,6 @@ import androidx.compose.ui.unit.sp
 import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-
 import com.example.issuetalk.R
 import com.example.issuetalk.core.common.util.clickWithRipple
 import com.example.issuetalk.core.designsystem.component.checkDialog
@@ -114,9 +114,10 @@ fun LoginScreen(
 
     Column(
         modifier = Modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
     ) {
-        Spacer(modifier = Modifier.height(30.dp))
+        Spacer(modifier = Modifier.weight(1f))
         Image(
             painter = painterResource(id = R.drawable.issuetalk),
             contentDescription = null,
@@ -224,7 +225,7 @@ fun LoginScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 34.dp, end = 34.dp)
-                .clip(RoundedCornerShape(35.dp))
+                .clip(RoundedCornerShape(15.dp))
         ) {
             Text(
                 stringResource(id = R.string.login),

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
@@ -3,14 +3,12 @@ package com.example.issuetalk.feature.auth
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.issuetalk.core.domain.repository.auth.AuthRepository
-import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
 @HiltViewModel
@@ -41,8 +39,8 @@ class LoginViewModel @Inject constructor(
             }
 
             authRepository.loginFirebase(
-                emailText.value.trim(),
-                passwordText.value.trim()
+                _emailText.value.trim(),
+                _passwordText.value.trim()
             ).onSuccess {
                 _eventChannel.send(LoginEvent.NavigateToHome)
             }.onFailure {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
@@ -2,16 +2,21 @@ package com.example.issuetalk.feature.auth
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.issuetalk.core.domain.repository.auth.AuthRepository
 import com.google.firebase.auth.FirebaseAuth
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
 
-
-class LoginViewModel : ViewModel() {
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
     private val _eventChannel = Channel<LoginEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
@@ -29,31 +34,23 @@ class LoginViewModel : ViewModel() {
         _passwordText.value = passwordText
     }
 
-    fun login() {
-        val auth = FirebaseAuth.getInstance()
-        viewModelScope.launch {
+    fun loginFirebase() = viewModelScope.launch {
             if (_emailText.value.trim().isEmpty() || _passwordText.value.trim().isEmpty()) {
                 _eventChannel.send(LoginEvent.ShowDialog(LOGIN_FIELD_EMPTY))
                 return@launch
             }
 
-            try {
-                val result =
-                    auth.signInWithEmailAndPassword(
-                        emailText.value.trim(),
-                        passwordText.value.trim()
-                    ).await()
-
-
-                if (result.user != null) {
-                    _eventChannel.send(LoginEvent.NavigateToHome)
-                }
-            } catch (e: Exception) {
+            authRepository.loginFirebase(
+                emailText.value.trim(),
+                passwordText.value.trim()
+            ).onSuccess {
+                _eventChannel.send(LoginEvent.NavigateToHome)
+            }.onFailure {
                 _eventChannel.send(LoginEvent.ShowDialog(LOGIN_ERROR))
             }
 
         }
-    }
+
 
     fun navigateToSignUp() {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
@@ -13,13 +13,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation.Companion.keyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
@@ -146,12 +149,11 @@ fun SignUpScreen(
     val passwordCheckFocusRequester = remember { FocusRequester() }
 
     Column(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize().imePadding().verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 
         CenterAlignedTopAppBar(
-
             title = {
                     Row(modifier = Modifier.wrapContentSize(),
                         verticalAlignment = Alignment.CenterVertically)
@@ -186,7 +188,7 @@ fun SignUpScreen(
                 navigationIconContentColor = Color.Black,
 
             ),
-            windowInsets = WindowInsets(top = 5.dp, bottom = 0.dp),
+            windowInsets = WindowInsets(top = 0.dp, bottom = 0.dp),
             modifier = Modifier.fillMaxWidth().drawBehind {
                 drawLine(
                     color = Color.Gray,

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
@@ -2,6 +2,7 @@ package com.example.issuetalk.feature.auth.signup
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,8 +11,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.InputTransformation.Companion.keyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
@@ -19,61 +23,135 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.issuetalk.R
 import com.example.issuetalk.core.designsystem.component.checkDialog
+import com.example.issuetalk.core.designsystem.theme.lightRed
+import com.example.issuetalk.core.designsystem.theme.primaryColor
 import com.example.issuetalk.core.designsystem.theme.subColor
-import com.google.firebase.Firebase
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
-import com.google.firebase.auth.userProfileChangeRequest
 
 @Composable
 fun SignUpRoute(
-    navigateToHome : () -> Unit
+    navigateToWelcome: () -> Unit,
+    popBackStack: () -> Unit,
+    viewModel: SignUpViewModel = viewModel()
 ) {
-    SignUpScreen()
+    val emailText by viewModel.emailText.collectAsStateWithLifecycle()
+    val nameText by viewModel.nameText.collectAsStateWithLifecycle()
+    val passwordText by viewModel.passwordText.collectAsStateWithLifecycle()
+    val passwordCheckText by viewModel.passwordCheckText.collectAsStateWithLifecycle()
+    val isNameValid by viewModel.isNameValid.collectAsStateWithLifecycle()
+    val isEmailValid by viewModel.isEmailValid.collectAsStateWithLifecycle()
+    val isPasswordValid by viewModel.isPasswordValid.collectAsStateWithLifecycle()
+    val isPasswordMatch by viewModel.isPasswordMatch.collectAsStateWithLifecycle()
+    var dialogMessage by remember { mutableStateOf<String?>(null) }
+
+
+    LaunchedEffect(true) {
+        viewModel.eventChannel.collect { event ->
+            when (event) {
+                is SignUpViewModel.SignUpEvent.NavigateToWelcome -> navigateToWelcome()
+                is SignUpViewModel.SignUpEvent.ShowDialog -> dialogMessage = event.message
+            }
+        }
+    }
+
+    SignUpScreen(
+        emailText,
+        nameText,
+        passwordText,
+        passwordCheckText,
+        isNameValid,
+        isEmailValid,
+        isPasswordValid,
+        isPasswordMatch,
+        viewModel::signUp,
+        viewModel::setEmailText,
+        viewModel::setNameText,
+        viewModel::setPasswordText,
+        viewModel::setPasswordCheckText,
+        popBackStack
+    )
+
+    dialogMessage?.let {
+        checkDialog(
+            onDismiss = { dialogMessage = null },
+            dialogText = it
+        )
+    }
 }
 
 @Composable
 fun SignUpScreen(
-
+    emailText: String,
+    nameText: String,
+    passwordText: String,
+    passwordCheckText: String,
+    isNameValid: Boolean,
+    isEmailValid: Boolean,
+    isPasswordValid: Boolean,
+    isPasswordMatch: Boolean,
+    signUp: () -> Unit,
+    onEmailChange: (String) -> Unit,
+    onNameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onPasswordCheckChange: (String) -> Unit,
+    popBackStack: () -> Unit
 ) {
 
-    val auth = FirebaseAuth.getInstance()
-
-    var emailText by remember { mutableStateOf("") }
-    var nameText by remember { mutableStateOf("") }
-    var pwText by remember { mutableStateOf("") }
-    var pwCheckTest by remember { mutableStateOf("") }
-    var showPwDialog by remember { mutableStateOf(false) }
-    var showSignUpErrorDialog by remember { mutableStateOf(false) }
+    val emailFocusRequester = remember { FocusRequester() }
+    val passwordFocusRequester = remember { FocusRequester() }
+    val passwordCheckFocusRequester = remember { FocusRequester() }
 
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        IconButton(onClick = {}) {
-            Icon(painter = painterResource(id = R.drawable.arrow_back), contentDescription = null,
-                modifier = Modifier
-                    .padding(start = 6.dp)
-                    .width(35.dp)
-                    .height(35.dp))
+        Box(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            IconButton(
+                onClick = {
+                    popBackStack()
+
+                },
+                modifier = Modifier.align(Alignment.TopStart)
+            ) {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
+                    contentDescription = "뒤로 가기",
+                    modifier = Modifier
+                        .padding(start = 10.dp, top = 15.dp)
+                        .width(30.dp)
+                        .height(30.dp)
+                )
+            }
         }
 
         Row(
@@ -81,168 +159,203 @@ fun SignUpScreen(
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(painter =  painterResource(id = R.drawable.issuetalk), contentDescription = null,
-                tint = Color.Unspecified
-                ,modifier = Modifier
-                    .width(55.dp)
-                    .height(55.dp)
+            Icon(
+                painter = painterResource(id = R.drawable.issuetalk), contentDescription = null,
+                tint = Color.Unspecified, modifier = Modifier
+                    .width(80.dp)
+                    .height(80.dp)
             )
-            Spacer(modifier = Modifier.width(10.dp))
-            Text(text = stringResource(
-                id = R.string.sign_up), style = TextStyle(fontSize = 20.sp), fontWeight = FontWeight.Bold)
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = stringResource(
+                    id = R.string.sign_up
+                ), style = TextStyle(fontSize = 25.sp), fontWeight = FontWeight.Bold
+            )
 
         }
-
-        Text(text = "이름", modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 20.dp, top = 20.dp),
-            style = TextStyle(fontSize = 20.sp)
+        Spacer(Modifier.height(25.dp))
+        Text(
+            text = "이름", modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 15.sp)
         )
+        Spacer(Modifier.height(10.dp))
         OutlinedTextField(
-
             colors = TextFieldDefaults.outlinedTextFieldColors(
                 focusedBorderColor = subColor,
-                unfocusedBorderColor = Color.Gray
+                unfocusedBorderColor = Color.Gray,
+                cursorColor = subColor
             ),
             value = nameText,
-            onValueChange = { newText -> nameText = newText },
-            placeholder = { Text("이름을 입력해주세요.") },
+            onValueChange = { onNameChange(it) },
+            placeholder = { Text("이름을 입력해주세요", style = TextStyle(fontSize = 14.sp)) },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 20.dp, end = 20.dp, top = 10.dp),
+                .padding(horizontal = 20.dp)
+                .height(50.dp),
             maxLines = 1,
-            textStyle = TextStyle(fontSize = 20.sp)
+            textStyle = TextStyle(fontSize = 14.sp),
+            keyboardOptions = KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Text,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = { emailFocusRequester.requestFocus() }
+            )
 
         )
-
-        Text(text = "이메일", modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 20.dp, top = 20.dp),
-            style = TextStyle(fontSize = 20.sp)
+        Spacer(Modifier.height(5.dp))
+        if (!isNameValid && nameText.isNotEmpty()) Text(
+            text = "이름은 1 ~ 12자 사이만 가능합니다", modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 12.sp, color = lightRed)
         )
+        Spacer(Modifier.height(25.dp))
+        Text(
+            text = "이메일", modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 15.sp)
+        )
+        Spacer(Modifier.height(10.dp))
         OutlinedTextField(
 
             colors = TextFieldDefaults.outlinedTextFieldColors(
                 focusedBorderColor = subColor,
-                unfocusedBorderColor = Color.Gray
+                unfocusedBorderColor = Color.Gray,
+                cursorColor = subColor
             ),
             value = emailText,
-            onValueChange = { newText -> emailText = newText },
-            placeholder = { Text("이메일을 입력해주세요.") },
+            onValueChange = { onEmailChange(it) },
+            placeholder = { Text("예: issueTalk@naver.com", style = TextStyle(fontSize = 14.sp)) },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 20.dp, end = 20.dp, top = 10.dp),
+                .padding(horizontal = 20.dp)
+                .height(50.dp)
+                .focusRequester(emailFocusRequester),
             maxLines = 1,
-            textStyle = TextStyle(fontSize = 20.sp),
+            textStyle = TextStyle(fontSize = 14.sp),
             keyboardOptions = KeyboardOptions.Default.copy(
-                keyboardType = KeyboardType.Email
+                keyboardType = KeyboardType.Email,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = { passwordFocusRequester.requestFocus() }
+            )
+        )
+
+        Spacer(Modifier.height(5.dp))
+        if (!isEmailValid && emailText.isNotEmpty()) Text(
+            text = "올바르지 않은 이메일 형식입니다", modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 12.sp, color = lightRed)
+        )
+        Spacer(Modifier.height(25.dp))
+        Text(
+            text = "비밀번호", modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 15.sp)
+        )
+        Spacer(Modifier.height(10.dp))
+        OutlinedTextField(
+            colors = TextFieldDefaults.outlinedTextFieldColors(
+                focusedBorderColor = subColor,
+                unfocusedBorderColor = Color.Gray,
+                cursorColor = subColor
+            ),
+            value = passwordText,
+            onValueChange = { onPasswordChange(it) },
+            placeholder = {
+                Text(
+                    "8~16자의 영문/숫자/특수문자 조합으로 입력",
+                    style = TextStyle(fontSize = 14.sp)
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .height(50.dp)
+                .focusRequester(passwordFocusRequester),
+            maxLines = 1,
+            textStyle = TextStyle(fontSize = 14.sp),
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions.Default.copy(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Next
+            ),
+            keyboardActions = KeyboardActions(
+                onNext = { passwordCheckFocusRequester.requestFocus() }
             )
 
-
         )
-
-        Text(text = "비밀번호", modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 20.dp, top = 20.dp),
-            style = TextStyle(fontSize = 20.sp)
+        Spacer(Modifier.height(5.dp))
+        if (!isPasswordValid && passwordText.isNotEmpty()) Text(
+            text = "올바르지 않은 비밀번호 형식입니다", modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 12.sp, color = lightRed)
         )
+        Spacer(Modifier.height(25.dp))
+        Text(
+            text = "비밀번호 확인", modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 15.sp)
+        )
+        Spacer(Modifier.height(10.dp))
         OutlinedTextField(
 
             colors = TextFieldDefaults.outlinedTextFieldColors(
                 focusedBorderColor = subColor,
-                unfocusedBorderColor = Color.Gray
+                unfocusedBorderColor = Color.Gray,
+                cursorColor = subColor
             ),
-            value = pwText,
-            onValueChange = { newText -> pwText = newText },
-            placeholder = { Text("비밀번호를 입력해주세요.") },
+            value = passwordCheckText,
+            onValueChange = { onPasswordCheckChange(it) },
+            placeholder = { Text("비밀번호를 다시 입력해주세요.", style = TextStyle(fontSize = 14.sp)) },
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 20.dp, end = 20.dp, top = 10.dp),
+                .padding(horizontal = 20.dp)
+                .height(50.dp)
+                .focusRequester(passwordCheckFocusRequester),
             maxLines = 1,
-            textStyle = TextStyle(fontSize = 20.sp),
+            textStyle = TextStyle(fontSize = 14.sp),
             visualTransformation = PasswordVisualTransformation(),
             keyboardOptions = KeyboardOptions.Default.copy(
                 keyboardType = KeyboardType.Password
             )
 
         )
-
-        Text(text = "비밀번호 확인", modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 20.dp, top = 20.dp),
-            style = TextStyle(fontSize = 20.sp)
-        )
-        OutlinedTextField(
-
-            colors = TextFieldDefaults.outlinedTextFieldColors(
-                focusedBorderColor = subColor,
-                unfocusedBorderColor = Color.Gray
-            ),
-            value = pwCheckTest,
-            onValueChange = { newText -> pwCheckTest = newText },
-            placeholder = { Text("비밀번호를 다시 입력해주세요.") },
-            modifier = Modifier
+        Spacer(Modifier.height(5.dp))
+        if (!isPasswordMatch && passwordCheckText.isNotEmpty()) Text(
+            text = "비밀번호가 일치하지 않습니다", modifier = Modifier
                 .fillMaxWidth()
-                .padding(start = 20.dp, end = 20.dp, top = 10.dp),
-            maxLines = 1,
-            textStyle = TextStyle(fontSize = 20.sp),
-            visualTransformation = PasswordVisualTransformation(),
-            keyboardOptions = KeyboardOptions.Default.copy(
-                keyboardType = KeyboardType.Password
-            )
-
+                .padding(start = 20.dp),
+            style = TextStyle(fontSize = 12.sp, color = lightRed)
         )
 
-        Spacer(modifier = Modifier.height(30.dp))
-        val context = LocalContext.current
+        Spacer(Modifier.weight(1f))
         Button(
             onClick = {
-
-                if (pwText != "" && pwText == pwCheckTest) {
-                    auth.createUserWithEmailAndPassword(emailText, pwText)
-                        .addOnCompleteListener { task ->
-                            if (task.isSuccessful) {
-                                // 회원가입 성공
-
-                                val user = Firebase.auth.currentUser
-
-                                val profileUpdates = userProfileChangeRequest {
-                                    displayName = nameText
-                                }
-
-                                user!!.updateProfile(profileUpdates)
-                                    .addOnCompleteListener { task ->
-                                        if (task.isSuccessful) {
-                                            Toast.makeText(context,"회원가입에 성공했습니다.",Toast.LENGTH_SHORT).show()
-//                                            navController.navigate("login")
-                                        }
-                                    }
-
-
-                            } else {
-                                // 회원가입 실패
-                              showSignUpErrorDialog = true
-                            }
-                        }
-                } else {
-                    showPwDialog = true
-                }
+                signUp()
             },
             colors = ButtonDefaults.buttonColors(subColor),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 20.dp, end = 20.dp)
+                .clip(RoundedCornerShape(15.dp))
         ) {
-            Text(stringResource(id = R.string.sign_up), color = Color.White,style = TextStyle(fontSize = 20.sp))
+            Text(
+                stringResource(id = R.string.finish),
+                color = Color.White,
+                style = TextStyle(fontSize = 20.sp)
+            )
         }
-
-        if(showPwDialog) {
-            checkDialog(onDismiss = { showPwDialog = false}, dialogText = "비밀번호가 일치하지 않습니다.")
-        }
-
-        if(showSignUpErrorDialog) {
-            checkDialog(onDismiss = { showSignUpErrorDialog = false}, dialogText = "올바르지 않은 이메일 형식입니다.")
-        }
+        Spacer(modifier = Modifier.height(60.dp))
     }
 }
 

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
@@ -6,11 +6,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 
@@ -20,12 +24,19 @@ import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.material.TextFieldDefaults
+import androidx.compose.material.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -35,9 +46,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -55,6 +69,7 @@ import com.example.issuetalk.core.designsystem.component.checkDialog
 import com.example.issuetalk.core.designsystem.theme.lightRed
 import com.example.issuetalk.core.designsystem.theme.primaryColor
 import com.example.issuetalk.core.designsystem.theme.subColor
+import com.example.issuetalk.core.designsystem.theme.topBarColor
 
 @Composable
 fun SignUpRoute(
@@ -107,6 +122,7 @@ fun SignUpRoute(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignUpScreen(
     emailText: String,
@@ -133,47 +149,56 @@ fun SignUpScreen(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Box(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            IconButton(
-                onClick = {
-                    popBackStack()
 
-                },
-                modifier = Modifier.align(Alignment.TopStart)
-            ) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                    contentDescription = "뒤로 가기",
-                    modifier = Modifier
-                        .padding(start = 10.dp, top = 15.dp)
-                        .width(30.dp)
-                        .height(30.dp)
+        CenterAlignedTopAppBar(
+
+            title = {
+                    Row(modifier = Modifier.wrapContentSize(),
+                        verticalAlignment = Alignment.CenterVertically)
+                    {
+                        Icon(
+                            painter = painterResource(id = R.drawable.issuetalk),
+                            contentDescription = null,
+                            tint = Color.Unspecified,
+                            modifier = Modifier
+                                .width(40.dp)
+                                .height(40.dp)
+                        )
+                        Spacer(Modifier.width(3.dp))
+                        Text(
+                            text = stringResource(id = R.string.sign_up),
+                            style = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Bold),
+                            color = Color.Black
+                        )
+                    }
+            },
+            navigationIcon = {
+                IconButton(onClick = { popBackStack() }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Default.KeyboardArrowLeft,
+                        contentDescription = "뒤로 가기",
+                    )
+                }
+
+            },
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = Color.White,
+                navigationIconContentColor = Color.Black,
+
+            ),
+            windowInsets = WindowInsets(top = 5.dp, bottom = 0.dp),
+            modifier = Modifier.fillMaxWidth().drawBehind {
+                drawLine(
+                    color = Color.Gray,
+                    start = Offset(0f, size.height),
+                    end = Offset(size.width, size.height),
+                    strokeWidth = 1.dp.toPx()
                 )
             }
-        }
+        )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Icon(
-                painter = painterResource(id = R.drawable.issuetalk), contentDescription = null,
-                tint = Color.Unspecified, modifier = Modifier
-                    .width(80.dp)
-                    .height(80.dp)
-            )
-            Spacer(modifier = Modifier.width(8.dp))
-            Text(
-                text = stringResource(
-                    id = R.string.sign_up
-                ), style = TextStyle(fontSize = 25.sp), fontWeight = FontWeight.Bold
-            )
 
-        }
-        Spacer(Modifier.height(25.dp))
+        Spacer(Modifier.weight(1f))
         Text(
             text = "이름", modifier = Modifier
                 .fillMaxWidth()
@@ -229,7 +254,12 @@ fun SignUpScreen(
             ),
             value = emailText,
             onValueChange = { onEmailChange(it) },
-            placeholder = { Text("예: issueTalk@naver.com", style = TextStyle(fontSize = 14.sp)) },
+            placeholder = {
+                Text(
+                    "예: issueTalk@naver.com",
+                    style = TextStyle(fontSize = 14.sp)
+                )
+            },
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 20.dp)

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.issuetalk.R
@@ -80,7 +81,7 @@ import com.example.issuetalk.core.designsystem.theme.topBarColor
 fun SignUpRoute(
     navigateToWelcome: () -> Unit,
     popBackStack: () -> Unit,
-    viewModel: SignUpViewModel = viewModel()
+    viewModel: SignUpViewModel = hiltViewModel()
 ) {
     val emailText by viewModel.emailText.collectAsStateWithLifecycle()
     val nameText by viewModel.nameText.collectAsStateWithLifecycle()
@@ -111,7 +112,7 @@ fun SignUpRoute(
         isEmailValid,
         isPasswordValid,
         isPasswordMatch,
-        viewModel::signUp,
+        viewModel::signUpFirebase,
         viewModel::setEmailText,
         viewModel::setNameText,
         viewModel::setPasswordText,

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
@@ -1,5 +1,6 @@
 package com.example.issuetalk.feature.auth.signup
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,6 +43,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -147,32 +149,38 @@ fun SignUpScreen(
     val emailFocusRequester = remember { FocusRequester() }
     val passwordFocusRequester = remember { FocusRequester() }
     val passwordCheckFocusRequester = remember { FocusRequester() }
+    val signUpAvailability =  isNameValid && isEmailValid && isPasswordValid && isPasswordMatch
 
     Column(
-        modifier = Modifier.fillMaxSize().imePadding().verticalScroll(rememberScrollState()),
+        modifier = Modifier
+            .fillMaxSize()
+            .imePadding()
+            .verticalScroll(rememberScrollState()),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
 
         CenterAlignedTopAppBar(
             title = {
-                    Row(modifier = Modifier.wrapContentSize(),
-                        verticalAlignment = Alignment.CenterVertically)
-                    {
-                        Icon(
-                            painter = painterResource(id = R.drawable.issuetalk),
-                            contentDescription = null,
-                            tint = Color.Unspecified,
-                            modifier = Modifier
-                                .width(40.dp)
-                                .height(40.dp)
-                        )
-                        Spacer(Modifier.width(3.dp))
-                        Text(
-                            text = stringResource(id = R.string.sign_up),
-                            style = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Bold),
-                            color = Color.Black
-                        )
-                    }
+                Row(
+                    modifier = Modifier.wrapContentSize(),
+                    verticalAlignment = Alignment.CenterVertically
+                )
+                {
+                    Icon(
+                        painter = painterResource(id = R.drawable.issuetalk),
+                        contentDescription = null,
+                        tint = Color.Unspecified,
+                        modifier = Modifier
+                            .width(40.dp)
+                            .height(40.dp)
+                    )
+                    Spacer(Modifier.width(3.dp))
+                    Text(
+                        text = stringResource(id = R.string.sign_up),
+                        style = TextStyle(fontSize = 18.sp, fontWeight = FontWeight.Bold),
+                        color = Color.Black
+                    )
+                }
             },
             navigationIcon = {
                 IconButton(onClick = { popBackStack() }) {
@@ -187,16 +195,18 @@ fun SignUpScreen(
                 containerColor = Color.White,
                 navigationIconContentColor = Color.Black,
 
-            ),
+                ),
             windowInsets = WindowInsets(top = 0.dp, bottom = 0.dp),
-            modifier = Modifier.fillMaxWidth().drawBehind {
-                drawLine(
-                    color = Color.Gray,
-                    start = Offset(0f, size.height),
-                    end = Offset(size.width, size.height),
-                    strokeWidth = 1.dp.toPx()
-                )
-            }
+            modifier = Modifier
+                .fillMaxWidth()
+                .drawBehind {
+                    drawLine(
+                        color = Color.Gray,
+                        start = Offset(0f, size.height),
+                        end = Offset(size.width, size.height),
+                        strokeWidth = 1.dp.toPx()
+                    )
+                }
         )
 
 
@@ -347,7 +357,9 @@ fun SignUpScreen(
                 cursorColor = subColor
             ),
             value = passwordCheckText,
-            onValueChange = { onPasswordCheckChange(it) },
+            onValueChange = {
+                onPasswordCheckChange(it)
+            },
             placeholder = { Text("비밀번호를 다시 입력해주세요.", style = TextStyle(fontSize = 14.sp)) },
             modifier = Modifier
                 .fillMaxWidth()
@@ -373,9 +385,11 @@ fun SignUpScreen(
         Spacer(Modifier.weight(1f))
         Button(
             onClick = {
-                signUp()
+                if (signUpAvailability) signUp()
             },
-            colors = ButtonDefaults.buttonColors(subColor),
+            colors = if (signUpAvailability) ButtonDefaults.buttonColors(subColor) else ButtonDefaults.buttonColors(
+                Color.Gray
+            ),
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(start = 20.dp, end = 20.dp)

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.issuetalk.feature.auth.signup
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,7 +33,7 @@ class SignUpViewModel @Inject constructor(
     val passwordText = _passwordText.asStateFlow()
 
     private val _passwordCheckText = MutableStateFlow("")
-    val passwordCheckText = _passwordText.asStateFlow()
+    val passwordCheckText = _passwordCheckText.asStateFlow()
 
     private val _isNameValid = MutableStateFlow(false)
     val isNameValid = _isNameValid.asStateFlow()
@@ -44,7 +45,7 @@ class SignUpViewModel @Inject constructor(
      val isPasswordValid = _isPasswordValid.asStateFlow()
 
     private val _isPasswordMatch = MutableStateFlow(false)
-    val isPasswordMatch = _isEmailValid.asStateFlow()
+    val isPasswordMatch = _isPasswordMatch.asStateFlow()
 
     fun setEmailText(emailText: String) {
         _emailText.value = emailText

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
@@ -1,0 +1,128 @@
+package com.example.issuetalk.feature.auth.signup
+
+import android.widget.Toast
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
+import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
+import com.google.firebase.auth.userProfileChangeRequest
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import javax.inject.Inject
+
+class SignUpViewModel @Inject constructor(
+
+): ViewModel() {
+    private val _eventChannel = Channel<SignUpEvent>()
+    val eventChannel = _eventChannel.receiveAsFlow()
+
+    private val _emailText = MutableStateFlow("")
+    val emailText = _emailText.asStateFlow()
+
+    private val _nameText = MutableStateFlow("")
+    val nameText = _nameText.asStateFlow()
+
+    private val _passwordText = MutableStateFlow("")
+    val passwordText = _passwordText.asStateFlow()
+
+    private val _passwordCheckText = MutableStateFlow("")
+    val passwordCheckText = _passwordText.asStateFlow()
+
+    private val _isNameValid = MutableStateFlow(false)
+    val isNameValid = _isNameValid.asStateFlow()
+
+    private val _isEmailValid = MutableStateFlow(false)
+    val isEmailValid = _isEmailValid.asStateFlow()
+
+    private val _isPasswordValid = MutableStateFlow(false)
+     val isPasswordValid = _isPasswordValid.asStateFlow()
+
+    private val _isPasswordMatch = MutableStateFlow(false)
+    val isPasswordMatch = _isEmailValid.asStateFlow()
+
+    fun setEmailText(emailText: String) {
+        _emailText.value = emailText
+        validateEmail(_emailText.value)
+    }
+
+    fun setNameText(nameText: String) {
+        _nameText.value = nameText
+        validateName()
+    }
+
+    fun setPasswordText(passwordText: String) {
+        _passwordText.value = passwordText
+        validatePassword()
+        validatePasswordMatch()
+    }
+
+    fun setPasswordCheckText(passwordCheckText: String) {
+        _passwordCheckText.value = passwordCheckText
+        validatePasswordMatch()
+    }
+
+    private fun validateName() {
+        val nicknameRegex = "^.$NAME_MIN_LENGTH,$NAME_MAX_LENGTH}$".toRegex()
+         _isNameValid.value = _nameText.value.trim().matches(nicknameRegex)
+    }
+
+    private fun validateEmail( ) {
+        val emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        _isEmailValid.value =  _emailText.value.trim().matches(emailRegex.toRegex())
+    }
+
+    private fun validatePassword() {
+        val regex = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[\\W_]).{$PASSWORD_MIN_LENGTH,$PASSWORD_MAX_LENGTH}$"
+        _isPasswordValid.value = _passwordText.value.trim().matches(Regex(regex))
+    }
+
+    private fun validatePasswordMatch() {
+        _isPasswordMatch.value = _passwordText.value.trim() == _passwordCheckText.value.trim()
+    }
+
+    fun signUp() {
+//        val auth = FirebaseAuth.getInstance()
+//        auth.createUserWithEmailAndPassword(emailText, pwText)
+//            .addOnCompleteListener { task ->
+//                if (task.isSuccessful) {
+//                    // 회원가입 성공
+//
+//                    val user = Firebase.auth.currentUser
+//
+//                    val profileUpdates = userProfileChangeRequest {
+//                        displayName = _nameText.value
+//                    }
+//
+//                    user!!.updateProfile(profileUpdates)
+//                        .addOnCompleteListener { task ->
+//                            if (task.isSuccessful) {
+//                                _eventChannel.send(SignUpEvent.NavigateToWelcome)
+//                            }
+//                        }
+//
+//
+//                }
+//            }
+    }
+
+    sealed class SignUpEvent {
+        data object NavigateToWelcome : SignUpEvent()
+        data class ShowDialog(val message: String) : SignUpEvent()
+    }
+
+    companion object {
+        private const val NAME_MIN_LENGTH = 1
+        private const val NAME_MAX_LENGTH = 12
+        private const val PASSWORD_MIN_LENGTH = 8
+        private const val PASSWORD_MAX_LENGTH = 16
+        private const val SIGNUP_ERROR = "회원가입에 실패했습니다"
+    }
+
+
+}

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
@@ -1,25 +1,20 @@
 package com.example.issuetalk.feature.auth.signup
 
-import android.util.Log
-import android.widget.Toast
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
-import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
-import com.google.firebase.Firebase
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
-import com.google.firebase.auth.userProfileChangeRequest
+import androidx.lifecycle.viewModelScope
+import com.example.issuetalk.core.domain.repository.auth.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@HiltViewModel
 class SignUpViewModel @Inject constructor(
-
-): ViewModel() {
+    private val authRepository: AuthRepository
+) : ViewModel() {
     private val _eventChannel = Channel<SignUpEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
@@ -87,29 +82,16 @@ class SignUpViewModel @Inject constructor(
         _isPasswordMatch.value = _passwordText.value.trim() == _passwordCheckText.value.trim()
     }
 
-    fun signUp() {
-//        val auth = FirebaseAuth.getInstance()
-//        auth.createUserWithEmailAndPassword(emailText, pwText)
-//            .addOnCompleteListener { task ->
-//                if (task.isSuccessful) {
-//                    // 회원가입 성공
-//
-//                    val user = Firebase.auth.currentUser
-//
-//                    val profileUpdates = userProfileChangeRequest {
-//                        displayName = _nameText.value
-//                    }
-//
-//                    user!!.updateProfile(profileUpdates)
-//                        .addOnCompleteListener { task ->
-//                            if (task.isSuccessful) {
-//                                _eventChannel.send(SignUpEvent.NavigateToWelcome)
-//                            }
-//                        }
-//
-//
-//                }
-//            }
+    fun signUpFirebase() = viewModelScope.launch {
+        authRepository.signUpFirebase(
+            _emailText.value.trim(),
+            _passwordText.value.trim(),
+            _nameText.value.trim()
+        ).onSuccess {
+            _eventChannel.send(SignUpEvent.NavigateToWelcome)
+        }.onFailure {
+            _eventChannel.send(SignUpEvent.ShowDialog(SIGNUP_ERROR))
+        }
     }
 
     sealed class SignUpEvent {
@@ -123,6 +105,7 @@ class SignUpViewModel @Inject constructor(
         private const val PASSWORD_MIN_LENGTH = 8
         private const val PASSWORD_MAX_LENGTH = 16
         private const val SIGNUP_ERROR = "회원가입에 실패했습니다"
+        private const val DUPLICATED_EMAIL = "이미 존재하는 이메일 입니다"
     }
 
 

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
@@ -48,7 +48,7 @@ class SignUpViewModel @Inject constructor(
 
     fun setEmailText(emailText: String) {
         _emailText.value = emailText
-        validateEmail(_emailText.value)
+        validateEmail()
     }
 
     fun setNameText(nameText: String) {
@@ -68,7 +68,7 @@ class SignUpViewModel @Inject constructor(
     }
 
     private fun validateName() {
-        val nicknameRegex = "^.$NAME_MIN_LENGTH,$NAME_MAX_LENGTH}$".toRegex()
+        val nicknameRegex = "^.{$NAME_MIN_LENGTH,$NAME_MAX_LENGTH}$".toRegex()
          _isNameValid.value = _nameText.value.trim().matches(nicknameRegex)
     }
 

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/navigation/SignUpNavigation.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/navigation/SignUpNavigation.kt
@@ -22,7 +22,6 @@ fun NavGraphBuilder.signUpScreen(
         SignUpRoute(
             navigateToWelcome = navigateToWelcome,
             popBackStack = popBackStack
-
         )
     }
 }

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/navigation/SignUpNavigation.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/navigation/SignUpNavigation.kt
@@ -15,11 +15,14 @@ fun NavController.navigateToSignUp(navOptions: NavOptions? = null) {
 }
 
 fun NavGraphBuilder.signUpScreen(
-    navigateToHome : () -> Unit
+    navigateToWelcome: () -> Unit,
+    popBackStack: () -> Unit
 ) {
     composable<SignUpRoute> {
-       SignUpRoute(
-            navigateToHome = navigateToHome
+        SignUpRoute(
+            navigateToWelcome = navigateToWelcome,
+            popBackStack = popBackStack
+
         )
     }
 }

--- a/app/src/main/java/com/example/issuetalk/feature/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/splash/SplashScreen.kt
@@ -41,8 +41,9 @@ fun SplashScreen(
 
     LaunchedEffect(true) {
         delay(500)
-        if(user == null) navigateToLogin()
-        else navigateToHome()
+        navigateToLogin()
+//        if(user == null) navigateToLogin()
+//        else navigateToHome()
     }
 
     Column (

--- a/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
+++ b/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
@@ -30,7 +30,6 @@ class MainActivity : ComponentActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             val navController = rememberNavController()
-//            val coroutineScope = rememberCoroutineScope()
             IssueTalkTheme {
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
+++ b/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.core.view.WindowCompat
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.issuetalk.core.designsystem.theme.IssueTalkTheme
@@ -26,6 +27,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         enableEdgeToEdge()
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             val navController = rememberNavController()
 //            val coroutineScope = rememberCoroutineScope()

--- a/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
+++ b/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
@@ -46,11 +46,7 @@ fun IssueTalkNavHost(
         )
         loginScreen(
             navigateToSignUp = {
-                navController.navigateToSignUp(
-                    navOptions {
-                        popUpTo<LoginRoute> { inclusive = true }
-                    }
-                )
+                navController.navigateToSignUp()
             },
             navigateToHome = {
                 navController.navigateToHome(
@@ -61,13 +57,14 @@ fun IssueTalkNavHost(
             }
         )
         signUpScreen(
-            navigateToHome = {
-                navController.navigateToHome(
-                    navOptions {
-                        popUpTo<HomeRoute> { inclusive = true }
-                    }
-                )
-            }
+            navigateToWelcome = {
+//                navController.navigateToHome(
+//                    navOptions {
+//                        popUpTo<HomeRoute> { inclusive = true }
+//                    }
+//                )
+            },
+            popBackStack = { navController.popBackStack() }
         )
         homeScreen(
 

--- a/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
+++ b/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
@@ -32,14 +32,14 @@ fun IssueTalkNavHost(
             navigateToLogin = {
                 navController.navigateToLogin(
                     navOptions {
-                        popUpTo<LoginRoute> { inclusive = true }
+                        popUpTo<SplashRoute> { inclusive = true }
                     }
                 )
             },
             navigateToHome = {
                 navController.navigateToHome(
                     navOptions {
-                        popUpTo<HomeRoute> { inclusive = true }
+                        popUpTo<SplashRoute> { inclusive = true }
                     }
                 )
             }
@@ -51,7 +51,7 @@ fun IssueTalkNavHost(
             navigateToHome = {
                 navController.navigateToHome(
                     navOptions {
-                        popUpTo<HomeRoute> { inclusive = true }
+                        popUpTo<LoginRoute> { inclusive = true }
                     }
                 )
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="dialog_confirm">확인</string>
     <string name="dialog_cancel">취소</string>
 
+    <string name="finish">완료</string>
+
 </resources>


### PR DESCRIPTION
### 작업 내용
- [x] 회원가입 화면 UI 수정
- [x] 회원가입 화면 로직 수정

![회원가입](https://github.com/user-attachments/assets/715b7b19-ae45-41c5-aa07-9352e309abd8)

### 참고 사항
- Firebase auth로 회원 관리가 번거로운 것 같아 OAuth를 사용하는 쪽을 고려 중이다.
- 이메일 인증을 필수로 하지 않을려 햇는데, 이메일, 비밀번호 찾기를 위해선 이메일 인증이 필수이다. 하지만 Firebase에선 회원가입 시에는 이메일 인증이 불가능하다는 단점이 있다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- Firebase 인증을 사용한 로그인 및 회원가입 기능 추가
	- 사용자 입력 유효성 검사 기능 도입

- **디자인 시스템**
	- 앱의 색상 팔레트 업데이트
	- 로그인 및 회원가입 화면 레이아웃 개선

- **의존성 주입**
	- Hilt를 사용한 의존성 주입 아키텍처 구현
	- Firebase 모듈 통합

- **버그 수정**
	- 스플래시 화면 탐색 로직 간소화
	- 창 관리 기능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->