### PR TITLE
[Feature] 카카오 로그인 추가

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-02-14T14:46:18.068775300Z">
+        <DropdownSelection timestamp="2025-02-15T11:18:39.149372500Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CN302TMEB" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\mj010\.android\avd\Pixel_2_API_33.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-02-10T10:50:19.817092700Z">
+        <DropdownSelection timestamp="2025-02-14T14:46:18.068775300Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\mj010\.android\avd\Pixel_7_Pro_API_34.avd" />
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=R3CN302TMEB" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,1 +1,2 @@
 /build
+local.properties

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
     implementation("androidx.activity:activity-compose:1.10.0")
-    implementation(platform("androidx.compose:compose-bom:2025.01.01"))
+    implementation(platform("androidx.compose:compose-bom:2025.02.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
@@ -76,17 +76,17 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2025.01.01"))
+    androidTestImplementation(platform("androidx.compose:compose-bom:2025.02.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 
-    implementation ("androidx.compose.material:material:1.7.7")
+    implementation ("androidx.compose.material:material:1.7.8")
     implementation("androidx.compose.material3:material3:1.3.1")
     implementation("androidx.compose.material3:material3-window-size-class:1.3.1")
-    implementation("androidx.compose.material3:material3-adaptive-navigation-suite:1.4.0-alpha07")
-    implementation ("androidx.navigation:navigation-compose:2.8.6")
+    implementation("androidx.compose.material3:material3-adaptive-navigation-suite:1.4.0-alpha08")
+    implementation ("androidx.navigation:navigation-compose:2.8.7")
     implementation("com.google.accompanist:accompanist-pager:0.28.0")
     implementation("com.google.accompanist:accompanist-pager-indicators:0.28.0")
 
@@ -98,6 +98,8 @@ dependencies {
     implementation("com.google.firebase:firebase-auth:23.2.0")
     implementation("com.google.android.gms:play-services-auth:21.3.0")
 
+    implementation("com.kakao.sdk:v2-user:2.20.6")
+    implementation ("com.kakao.sdk:v2-cert:2.20.6")
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
     implementation("androidx.datastore:datastore-preferences:1.1.2")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,7 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("kotlin-kapt")
     id("com.google.devtools.ksp")
@@ -20,9 +24,22 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        val properties = Properties().apply {
+            load(FileInputStream(rootProject.file("local.properties")))
+        }
+
+        buildConfigField(
+            "String",
+            "KAKAO_NATIVE_APP_KEY",
+            properties["KAKAO_NATIVE_APP_KEY"] as String
+        )
+
+        manifestPlaceholders["KAKAO_REDIRECT_URI"] = properties["KAKAO_REDIRECT_URI"] as String
     }
 
     buildTypes {
@@ -43,6 +60,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
@@ -52,6 +70,7 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
         <activity
             android:name=".main.MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.KindDiscussion">
             <intent-filter>
@@ -27,6 +26,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="kakaoccecf62a10b57cf137be324f5ab43f39" />
+            </intent-filter>
+        </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
 
                 <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
                 <data android:host="oauth"
-                    android:scheme="kakaoccecf62a10b57cf137be324f5ab43f39" />
+                    android:scheme="${KAKAO_REDIRECT_URI}" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/example/issuetalk/core/data/di/RepositoryModule.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/di/RepositoryModule.kt
@@ -18,5 +18,4 @@ interface RepositoryModule {
         authRepositoryImpl : AuthRepositoryImpl
     ) : AuthRepository
 
-
 }

--- a/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
@@ -4,20 +4,32 @@ import UserInformationRequest
 import UserInformationResponse
 import com.example.issuetalk.core.domain.repository.auth.AuthRepository
 import com.example.issuetalk.core.network.source.auth.AuthDataSource
+import com.example.issuetalk.core.network.source.auth.LocalAuthDataSource
 import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
-    private val authDataSource: AuthDataSource
+    private val authDataSource: AuthDataSource,
+    private val localDataSource: LocalAuthDataSource
 ) : AuthRepository {
-    override suspend fun loginFirebaseWithKakao(idToken : String): Result<Unit> = authDataSource.loginFirebaseWithKakao(idToken)
+    override suspend fun loginFirebaseWithKakao(idToken: String): Result<Unit> =
+        authDataSource.loginFirebaseWithKakao(idToken)
 
     override suspend fun verifyRegistered(): Result<Boolean> = authDataSource.verifyRegistered()
 
-    override suspend fun getUserInformation(): Result<UserInformationResponse> = authDataSource.getUserInformation()
+    override suspend fun getUserInformation(): Result<UserInformationResponse> =
+        authDataSource.getUserInformation()
 
-    override suspend fun setUserInformation(userInformationRequest: UserInformationRequest): Result<Unit> = authDataSource.setUserInformation(userInformationRequest)
+    override suspend fun setUserInformation(userInformationRequest: UserInformationRequest): Result<Unit> =
+        authDataSource.setUserInformation(userInformationRequest)
 
-    override suspend fun deleteUserInformation(): Result<Unit> = authDataSource.deleteUserInformation()
+    override suspend fun deleteUserInformation(): Result<Unit> =
+        authDataSource.deleteUserInformation()
+
+    override fun saveShowHome() {
+        localDataSource.saveShowHome()
+    }
+
+    override fun getShowHome() = localDataSource.getShowHome()
 
 
 }

--- a/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
@@ -31,5 +31,6 @@ class AuthRepositoryImpl @Inject constructor(
 
     override fun getShowHome() = localDataSource.getShowHome()
 
+    override fun clearShowHome() = localDataSource.clearShowHome()
 
 }

--- a/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
@@ -7,6 +7,8 @@ import javax.inject.Inject
 class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource
 ) : AuthRepository {
+    override suspend fun loginFirebaseWithKakao(idToken : String): Result<Unit> = authDataSource.loginFirebaseWithKakao(idToken)
+
     override suspend fun signUp(): Result<Unit> = authDataSource.signUp()
 
 }

--- a/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package com.example.issuetalk.core.data.repository.auth
 
+import UserInformationRequest
+import UserInformationResponse
 import com.example.issuetalk.core.domain.repository.auth.AuthRepository
 import com.example.issuetalk.core.network.source.auth.AuthDataSource
 import javax.inject.Inject
@@ -9,6 +11,13 @@ class AuthRepositoryImpl @Inject constructor(
 ) : AuthRepository {
     override suspend fun loginFirebaseWithKakao(idToken : String): Result<Unit> = authDataSource.loginFirebaseWithKakao(idToken)
 
-    override suspend fun signUp(): Result<Unit> = authDataSource.signUp()
+    override suspend fun verifyRegistered(): Result<Boolean> = authDataSource.verifyRegistered()
+
+    override suspend fun getUserInformation(): Result<UserInformationResponse> = authDataSource.getUserInformation()
+
+    override suspend fun setUserInformation(userInformationRequest: UserInformationRequest): Result<Unit> = authDataSource.setUserInformation(userInformationRequest)
+
+    override suspend fun deleteUserInformation(): Result<Unit> = authDataSource.deleteUserInformation()
+
 
 }

--- a/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/example/issuetalk/core/data/repository/auth/AuthRepositoryImpl.kt
@@ -7,8 +7,6 @@ import javax.inject.Inject
 class AuthRepositoryImpl @Inject constructor(
     private val authDataSource: AuthDataSource
 ) : AuthRepository {
-    override suspend fun loginKakao(): Result<Unit> = authDataSource.loginKakao()
     override suspend fun signUp(): Result<Unit> = authDataSource.signUp()
-
 
 }

--- a/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
@@ -1,5 +1,6 @@
 package com.example.issuetalk.core.domain.repository.auth
 
 interface AuthRepository {
+    suspend fun loginFirebaseWithKakao(idToken : String) : Result<Unit>
     suspend fun signUp() : Result<Unit>
 }

--- a/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
@@ -10,4 +10,6 @@ interface AuthRepository {
     suspend fun getUserInformation() : Result<UserInformationResponse>
     suspend fun setUserInformation(userInformationRequest: UserInformationRequest) : Result<Unit>
     suspend fun deleteUserInformation() : Result<Unit>
+    fun saveShowHome()
+    fun getShowHome() : Boolean
 }

--- a/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
@@ -1,6 +1,13 @@
 package com.example.issuetalk.core.domain.repository.auth
 
+import UserInformationRequest
+import UserInformationResponse
+
+
 interface AuthRepository {
     suspend fun loginFirebaseWithKakao(idToken : String) : Result<Unit>
-    suspend fun signUp() : Result<Unit>
+    suspend fun verifyRegistered() : Result<Boolean>
+    suspend fun getUserInformation() : Result<UserInformationResponse>
+    suspend fun setUserInformation(userInformationRequest: UserInformationRequest) : Result<Unit>
+    suspend fun deleteUserInformation() : Result<Unit>
 }

--- a/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
@@ -12,4 +12,5 @@ interface AuthRepository {
     suspend fun deleteUserInformation() : Result<Unit>
     fun saveShowHome()
     fun getShowHome() : Boolean
+    fun clearShowHome()
 }

--- a/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
+++ b/app/src/main/java/com/example/issuetalk/core/domain/repository/auth/AuthRepository.kt
@@ -1,6 +1,5 @@
 package com.example.issuetalk.core.domain.repository.auth
 
 interface AuthRepository {
-    suspend fun loginKakao() : Result<Unit>
     suspend fun signUp() : Result<Unit>
 }

--- a/app/src/main/java/com/example/issuetalk/core/network/constant/Constant.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/constant/Constant.kt
@@ -1,0 +1,6 @@
+package com.example.issuetalk.core.network.constant
+
+const val USER_INFORMATION_COLLECTION = "user_information"
+const val SUBJECT_COLLECTION = "subject"
+const val CHOICE_COLLECTION = "choice"
+const val POST_COLLECTION = "post"

--- a/app/src/main/java/com/example/issuetalk/core/network/constant/Constant.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/constant/Constant.kt
@@ -1,5 +1,6 @@
 package com.example.issuetalk.core.network.constant
 
+const val OIDC_KAKAO_PROVIDER_ID = "oidc.kakao"
 const val USER_INFORMATION_COLLECTION = "user_information"
 const val SUBJECT_COLLECTION = "subject"
 const val CHOICE_COLLECTION = "choice"

--- a/app/src/main/java/com/example/issuetalk/core/network/model/auth/UserInformation.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/model/auth/UserInformation.kt
@@ -1,0 +1,13 @@
+data class UserInformationRequest(
+    val userId: String,
+    val name: String,
+    val gender: String,
+    val birthYear: Int
+)
+
+data class UserInformationResponse(
+    val userId: String = "",
+    val name: String = "",
+    val gender: String = "",
+    val birthYear: Int = 0
+)

--- a/app/src/main/java/com/example/issuetalk/core/network/model/auth/UserInformation.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/model/auth/UserInformation.kt
@@ -1,12 +1,10 @@
 data class UserInformationRequest(
-    val userId: String,
     val name: String,
     val gender: String,
     val birthYear: Int
 )
 
 data class UserInformationResponse(
-    val userId: String = "",
     val name: String = "",
     val gender: String = "",
     val birthYear: Int = 0

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -3,9 +3,12 @@ package com.example.issuetalk.core.network.source.auth
 
 import UserInformationRequest
 import UserInformationResponse
+import com.example.issuetalk.core.network.constant.OIDC_KAKAO_PROVIDER_ID
 import com.google.firebase.firestore.toObject
 import com.example.issuetalk.core.network.constant.USER_INFORMATION_COLLECTION
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
 import com.google.firebase.auth.oAuthCredential
 import com.google.firebase.firestore.FirebaseFirestore
 
@@ -21,8 +24,7 @@ class AuthDataSource @Inject constructor(
 
     fun loginFirebaseWithKakao(idToken : String) : Result<Unit> = runCatching {
         UserApiClient.instance.accessTokenInfo { accessTokenInfo, error ->
-            val providerId = "oidc.kakao"
-            val credential = oAuthCredential(providerId) {
+            val credential = oAuthCredential(OIDC_KAKAO_PROVIDER_ID) {
                 setIdToken(idToken)
             }
 
@@ -72,6 +74,10 @@ class AuthDataSource @Inject constructor(
             .await()
     }
 
-
-
 }
+
+fun getUserId() : String {
+    val auth = Firebase.auth
+    return requireNotNull(auth.currentUser?.uid)
+}
+

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -22,15 +22,11 @@ class AuthDataSource @Inject constructor(
     private val firebaseFireStore : FirebaseFirestore
 ) {
 
-    fun loginFirebaseWithKakao(idToken : String) : Result<Unit> = runCatching {
-        UserApiClient.instance.accessTokenInfo { accessTokenInfo, error ->
+    suspend fun loginFirebaseWithKakao(idToken : String) : Result<Unit> = runCatching {
             val credential = oAuthCredential(OIDC_KAKAO_PROVIDER_ID) {
                 setIdToken(idToken)
             }
-
-            firebaseAuth.signInWithCredential(credential)
-
-        }
+            firebaseAuth.signInWithCredential(credential).await()
     }
 
     suspend fun verifyRegistered() : Result<Boolean> = runCatching {

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -76,8 +76,3 @@ class AuthDataSource @Inject constructor(
 
 }
 
-fun getUserId() : String {
-    val auth = Firebase.auth
-    return requireNotNull(auth.currentUser?.uid)
-}
-

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -9,8 +9,6 @@ import javax.inject.Inject
 class AuthDataSource @Inject constructor(
     private val firebaseAuth: FirebaseAuth
 ) {
-    suspend fun loginKakao(): Result<Unit> = runCatching {
-    }
 
     suspend fun signUp(): Result<Unit> = runCatching {
 //        firebaseAuth.createUserWithEmailAndPassword(email, password).await()

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -1,18 +1,22 @@
 package com.example.issuetalk.core.network.source.auth
 
 
-import android.util.Log
-import com.google.firebase.Firebase
+import UserInformationRequest
+import UserInformationResponse
+import com.google.firebase.firestore.toObject
+import com.example.issuetalk.core.network.constant.USER_INFORMATION_COLLECTION
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.auth
 import com.google.firebase.auth.oAuthCredential
+import com.google.firebase.firestore.FirebaseFirestore
+
 import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.tasks.await
 
 import javax.inject.Inject
 
 class AuthDataSource @Inject constructor(
-    private val firebaseAuth: FirebaseAuth
+    private val firebaseAuth: FirebaseAuth,
+    private val firebaseFireStore : FirebaseFirestore
 ) {
 
     fun loginFirebaseWithKakao(idToken : String) : Result<Unit> = runCatching {
@@ -27,13 +31,47 @@ class AuthDataSource @Inject constructor(
         }
     }
 
-     fun signUp(): Result<Unit> = runCatching {
-//        firebaseAuth.createUserWithEmailAndPassword(email, password).await()
-//            val user = firebaseAuth.currentUser
-//            val profileUpdates = userProfileChangeRequest {
-//                displayName = name
-//            }
-//            user!!.updateProfile(profileUpdates).await()
-//        }
+    suspend fun verifyRegistered() : Result<Boolean> = runCatching {
+        val userId = firebaseAuth.currentUser!!.uid
+
+        val document = firebaseFireStore.collection(USER_INFORMATION_COLLECTION)
+            .document(userId)
+            .get()
+            .await()
+
+        document.toObject<UserInformationResponse>() != null
     }
+
+    suspend fun getUserInformation() : Result<UserInformationResponse> = runCatching {
+        val userId = firebaseAuth.currentUser!!.uid
+
+        val document = firebaseFireStore.collection(USER_INFORMATION_COLLECTION)
+            .document(userId)
+            .get()
+            .await()
+
+        requireNotNull(document.toObject<UserInformationResponse>())
+    }
+
+    suspend fun setUserInformation(userInformationRequest: UserInformationRequest) : Result<Unit> = runCatching {
+        val userId = firebaseAuth.currentUser!!.uid
+
+        firebaseFireStore.collection(USER_INFORMATION_COLLECTION)
+            .document(userId)
+            .set(userInformationRequest)
+            .await()
+
+    }
+
+    suspend fun deleteUserInformation() : Result<Unit> = runCatching {
+        val userId = firebaseAuth.currentUser!!.uid
+
+        firebaseFireStore.collection(USER_INFORMATION_COLLECTION)
+            .document(userId)
+            .delete()
+            .await()
+    }
+
+
+
 }

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/AuthDataSource.kt
@@ -1,16 +1,33 @@
 package com.example.issuetalk.core.network.source.auth
 
-import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
+
+import android.util.Log
+import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.userProfileChangeRequest
+import com.google.firebase.auth.auth
+import com.google.firebase.auth.oAuthCredential
+import com.kakao.sdk.user.UserApiClient
 import kotlinx.coroutines.tasks.await
+
 import javax.inject.Inject
 
 class AuthDataSource @Inject constructor(
     private val firebaseAuth: FirebaseAuth
 ) {
 
-    suspend fun signUp(): Result<Unit> = runCatching {
+    fun loginFirebaseWithKakao(idToken : String) : Result<Unit> = runCatching {
+        UserApiClient.instance.accessTokenInfo { accessTokenInfo, error ->
+            val providerId = "oidc.kakao"
+            val credential = oAuthCredential(providerId) {
+                setIdToken(idToken)
+            }
+
+            firebaseAuth.signInWithCredential(credential)
+
+        }
+    }
+
+     fun signUp(): Result<Unit> = runCatching {
 //        firebaseAuth.createUserWithEmailAndPassword(email, password).await()
 //            val user = firebaseAuth.currentUser
 //            val profileUpdates = userProfileChangeRequest {

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/LocalAuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/LocalAuthDataSource.kt
@@ -5,17 +5,30 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class LocalAuthDataSource @Inject constructor(
-    @ApplicationContext private val context : Context
+    @ApplicationContext private val context: Context
 ) {
     fun saveShowHome() {
-        val sharedPreferences = context.getSharedPreferences("auth_pref", Context.MODE_PRIVATE)
+        val sharedPreferences = context.getSharedPreferences(AUTH_PREF, Context.MODE_PRIVATE)
         val editor = sharedPreferences.edit()
-        editor.putBoolean("showHome", true)
+        editor.putBoolean(KEY_SHOW_HOME, true)
         editor.apply()
     }
 
-     fun getShowHome(): Boolean {
-        val sharedPreferences = context.getSharedPreferences("auth_pref", Context.MODE_PRIVATE)
-        return sharedPreferences.getBoolean("showHome", false)
+    fun getShowHome(): Boolean {
+        val sharedPreferences = context.getSharedPreferences(AUTH_PREF, Context.MODE_PRIVATE)
+        return sharedPreferences.getBoolean(KEY_SHOW_HOME, false)
+    }
+
+    fun clearShowHome() {
+        context.getSharedPreferences(AUTH_PREF, Context.MODE_PRIVATE)
+            .edit()
+            .remove(KEY_SHOW_HOME)
+            .apply()
+    }
+
+
+    companion object {
+        private const val AUTH_PREF = "auth_pref"
+        private const val KEY_SHOW_HOME = "showHome"
     }
 }

--- a/app/src/main/java/com/example/issuetalk/core/network/source/auth/LocalAuthDataSource.kt
+++ b/app/src/main/java/com/example/issuetalk/core/network/source/auth/LocalAuthDataSource.kt
@@ -1,0 +1,21 @@
+package com.example.issuetalk.core.network.source.auth
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+
+class LocalAuthDataSource @Inject constructor(
+    @ApplicationContext private val context : Context
+) {
+    fun saveShowHome() {
+        val sharedPreferences = context.getSharedPreferences("auth_pref", Context.MODE_PRIVATE)
+        val editor = sharedPreferences.edit()
+        editor.putBoolean("showHome", true)
+        editor.apply()
+    }
+
+     fun getShowHome(): Boolean {
+        val sharedPreferences = context.getSharedPreferences("auth_pref", Context.MODE_PRIVATE)
+        return sharedPreferences.getBoolean("showHome", false)
+    }
+}

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -2,11 +2,9 @@ package com.example.issuetalk.feature.auth
 
 
 import android.content.Context
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -28,7 +26,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -36,12 +33,6 @@ import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
 import com.example.issuetalk.R
 import com.example.issuetalk.core.common.util.clickWithRipple
 import com.example.issuetalk.core.designsystem.component.checkDialog
-import com.google.firebase.Firebase
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.OAuthProvider
-import com.google.firebase.auth.auth
-import com.google.firebase.auth.oAuthCredential
-import com.kakao.sdk.auth.AuthApiClient
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
@@ -65,7 +56,7 @@ fun LoginRoute(
             when (event) {
                 is LoginEvent.NavigateToHome -> navigateToHome()
                 is LoginEvent.NavigateToSignUp -> navigateToSignUp()
-                is LoginEvent.ShowDialog -> dialogMessage = event.message
+                is LoginEvent.LoginError -> dialogMessage = event.message
             }
         }
     }
@@ -149,7 +140,7 @@ private fun loginKakao(
 ) {
     val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         if (error != null) {
-            showDialog("로그인에 실패했습니다" + error.toString())
+            showDialog("로그인에 실패했습니다")
         } else if (token != null) {
             loginFirebaseWithKakao(token.idToken!!)
         }
@@ -159,7 +150,7 @@ private fun loginKakao(
     if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
         UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
             if (error != null) {
-                showDialog("로그인에 실패했습니다." + error.toString())
+                showDialog("로그인에 실패했습니다.")
                 // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
                 // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
                 if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -63,7 +63,7 @@ fun LoginRoute(
 
     LoginScreen(
         loginFirebaseWithKakao = viewModel::loginFirebaseWithKakao,
-        navigateToHome = viewModel::navigateToHome,
+        navigateToHomeWithoutLogin = viewModel::navigateToHomeWithoutLogin,
         showDialog = ::showDialog
     )
 
@@ -78,8 +78,7 @@ fun LoginRoute(
 @Composable
 fun LoginScreen(
     loginFirebaseWithKakao: (String) -> Unit,
-
-    navigateToHome: () -> Unit,
+    navigateToHomeWithoutLogin: () -> Unit,
     showDialog: (String) -> Unit
 ) {
     val context = LocalContext.current
@@ -122,7 +121,7 @@ fun LoginScreen(
             color = Color.Black,
             style = TextStyle(fontSize = 16.sp),
             modifier = Modifier.clickWithRipple {
-                navigateToHome()
+                navigateToHomeWithoutLogin()
             }
 
         )

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -72,7 +72,6 @@ fun LoginRoute(
 
     LoginScreen(
         loginFirebaseWithKakao = viewModel::loginFirebaseWithKakao,
-        navigateToSignUp = viewModel::navigateToSignUp,
         navigateToHome = viewModel::navigateToHome,
         showDialog = ::showDialog
     )
@@ -88,7 +87,7 @@ fun LoginRoute(
 @Composable
 fun LoginScreen(
     loginFirebaseWithKakao: (String) -> Unit,
-    navigateToSignUp: () -> Unit,
+
     navigateToHome: () -> Unit,
     showDialog: (String) -> Unit
 ) {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -63,7 +63,7 @@ fun LoginRoute(
 
     LoginScreen(
         loginFirebaseWithKakao = viewModel::loginFirebaseWithKakao,
-        navigateToHomeWithoutLogin = viewModel::navigateToHomeWithoutLogin,
+        navigateToHomeWithoutLogin  = viewModel::navigateToHomeWithoutLogin,
         showDialog = ::showDialog
     )
 

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -36,6 +36,12 @@ import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
 import com.example.issuetalk.R
 import com.example.issuetalk.core.common.util.clickWithRipple
 import com.example.issuetalk.core.designsystem.component.checkDialog
+import com.google.firebase.Firebase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.OAuthProvider
+import com.google.firebase.auth.auth
+import com.google.firebase.auth.oAuthCredential
+import com.kakao.sdk.auth.AuthApiClient
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
@@ -50,7 +56,7 @@ fun LoginRoute(
 ) {
     var dialogMessage by remember { mutableStateOf<String?>(null) }
 
-    fun showDialog(message : String) {
+    fun showDialog(message: String) {
         dialogMessage = message
     }
 
@@ -65,6 +71,7 @@ fun LoginRoute(
     }
 
     LoginScreen(
+        loginFirebaseWithKakao = viewModel::loginFirebaseWithKakao,
         navigateToSignUp = viewModel::navigateToSignUp,
         navigateToHome = viewModel::navigateToHome,
         showDialog = ::showDialog
@@ -80,9 +87,10 @@ fun LoginRoute(
 
 @Composable
 fun LoginScreen(
+    loginFirebaseWithKakao: (String) -> Unit,
     navigateToSignUp: () -> Unit,
     navigateToHome: () -> Unit,
-    showDialog : (String) -> Unit
+    showDialog: (String) -> Unit
 ) {
     val context = LocalContext.current
 
@@ -106,13 +114,16 @@ fun LoginScreen(
             style = TextStyle(fontSize = 48.sp, fontFamily = FontFamily(Font(R.font.app_title)))
         )
         Spacer(modifier = Modifier.height(15.dp))
-        Text("같은 이슈, 다른 생각, 새로운 시각", style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.SemiBold))
+        Text(
+            "같은 이슈, 다른 생각, 새로운 시각",
+            style = TextStyle(fontSize = 17.sp, fontWeight = FontWeight.SemiBold)
+        )
         Spacer(modifier = Modifier.height(60.dp))
         Image(
             painter = painterResource(R.drawable.kakao_login),
             contentDescription = "카카오 로그인",
             modifier = Modifier.clickWithRipple {
-                loginKakao(context, showDialog)
+                loginKakao(context, showDialog, loginFirebaseWithKakao)
             }
         )
         Spacer(Modifier.height(24.dp))
@@ -133,21 +144,23 @@ fun LoginScreen(
 
 
 private fun loginKakao(
-    context : Context,
-    showDialog: (String) -> Unit
+    context: Context,
+    showDialog: (String) -> Unit,
+    loginFirebaseWithKakao: (String) -> Unit
 ) {
     val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         if (error != null) {
-           showDialog(error.toString())
+            showDialog("로그인에 실패했습니다" + error.toString())
         } else if (token != null) {
-            Log.d("kakao", "카카오계정으로 로그인 성공 ${token.accessToken}")
+            loginFirebaseWithKakao(token.idToken!!)
         }
+
     }
 
     if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
         UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
             if (error != null) {
-
+                showDialog("로그인에 실패했습니다." + error.toString())
                 // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
                 // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
                 if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
@@ -157,7 +170,7 @@ private fun loginKakao(
                 // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
                 UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
             } else if (token != null) {
-
+                loginFirebaseWithKakao(token.idToken!!)
             }
         }
     } else {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginScreen.kt
@@ -1,6 +1,8 @@
 package com.example.issuetalk.feature.auth
 
 
+import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -19,6 +21,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -33,6 +36,10 @@ import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
 import com.example.issuetalk.R
 import com.example.issuetalk.core.common.util.clickWithRipple
 import com.example.issuetalk.core.designsystem.component.checkDialog
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
 
 
 @Composable
@@ -42,6 +49,10 @@ fun LoginRoute(
     viewModel: LoginViewModel = hiltViewModel()
 ) {
     var dialogMessage by remember { mutableStateOf<String?>(null) }
+
+    fun showDialog(message : String) {
+        dialogMessage = message
+    }
 
     LaunchedEffect(true) {
         viewModel.eventChannel.collect { event ->
@@ -54,9 +65,9 @@ fun LoginRoute(
     }
 
     LoginScreen(
-        loginKakao = viewModel::loginKakao,
         navigateToSignUp = viewModel::navigateToSignUp,
-        navigateToHome = viewModel::navigateToHome
+        navigateToHome = viewModel::navigateToHome,
+        showDialog = ::showDialog
     )
 
     dialogMessage?.let {
@@ -69,10 +80,11 @@ fun LoginRoute(
 
 @Composable
 fun LoginScreen(
-    loginKakao: () -> Unit,
     navigateToSignUp: () -> Unit,
     navigateToHome: () -> Unit,
+    showDialog : (String) -> Unit
 ) {
+    val context = LocalContext.current
 
 
     Column(
@@ -100,8 +112,7 @@ fun LoginScreen(
             painter = painterResource(R.drawable.kakao_login),
             contentDescription = "카카오 로그인",
             modifier = Modifier.clickWithRipple {
-                loginKakao()
-                navigateToSignUp()
+                loginKakao(context, showDialog)
             }
         )
         Spacer(Modifier.height(24.dp))
@@ -111,7 +122,6 @@ fun LoginScreen(
             style = TextStyle(fontSize = 16.sp),
             modifier = Modifier.clickWithRipple {
                 navigateToHome()
-
             }
 
         )
@@ -122,9 +132,44 @@ fun LoginScreen(
 }
 
 
-@Preview(showBackground = true)
-@Composable
-fun LoginPreview() {
-    LoginScreen({}, {}, {})
+private fun loginKakao(
+    context : Context,
+    showDialog: (String) -> Unit
+) {
+    val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+        if (error != null) {
+           showDialog(error.toString())
+        } else if (token != null) {
+            Log.d("kakao", "카카오계정으로 로그인 성공 ${token.accessToken}")
+        }
+    }
+
+    if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+        UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+            if (error != null) {
+
+                // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
+                // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
+                if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                    return@loginWithKakaoTalk
+                }
+
+                // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+            } else if (token != null) {
+
+            }
+        }
+    } else {
+        UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+    }
 }
+
+
+//
+//@Preview(showBackground = true)
+//@Composable
+//fun LoginPreview() {
+//    LoginScreen({}, {})
+//}
 

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
@@ -25,7 +25,6 @@ class LoginViewModel @Inject constructor(
     private val _eventChannel = Channel<LoginEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
-
     fun navigateToSignUp() {
         viewModelScope.launch {
             _eventChannel.send(LoginEvent.NavigateToSignUp)
@@ -36,6 +35,15 @@ class LoginViewModel @Inject constructor(
         viewModelScope.launch {
             _eventChannel.send(LoginEvent.NavigateToHome)
         }
+    }
+
+    fun loginFirebaseWithKakao(idToken: String) = viewModelScope.launch {
+        authRepository.loginFirebaseWithKakao(idToken)
+            .onSuccess {
+                Log.d("로그인", "성공")
+            }.onFailure {
+                _eventChannel.send(LoginEvent.ShowDialog(LOGIN_ERROR))
+            }
     }
 
     sealed class LoginEvent {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
@@ -25,13 +25,12 @@ class LoginViewModel @Inject constructor(
     private val _eventChannel = Channel<LoginEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
-    fun navigateToHome() {
-        viewModelScope.launch {
-            _eventChannel.send(LoginEvent.NavigateToHome)
-        }
+     fun navigateToHomeWithoutLogin() = viewModelScope.launch {
+         authRepository.saveShowHome()
+        _eventChannel.send(LoginEvent.NavigateToHome)
     }
 
-      fun loginFirebaseWithKakao(idToken: String) = viewModelScope.launch {
+    fun loginFirebaseWithKakao(idToken: String) = viewModelScope.launch {
         authRepository.loginFirebaseWithKakao(idToken)
             .onSuccess {
                 verifyResitered()
@@ -43,7 +42,8 @@ class LoginViewModel @Inject constructor(
     private suspend fun verifyResitered() = viewModelScope.launch {
         authRepository.verifyRegistered()
             .onSuccess { isRegistered ->
-                if(isRegistered) {
+                if (isRegistered) {
+                    authRepository.saveShowHome()
                     _eventChannel.send(LoginEvent.NavigateToHome)
                     return@onSuccess
                 }
@@ -51,7 +51,7 @@ class LoginViewModel @Inject constructor(
                 _eventChannel.send(LoginEvent.NavigateToSignUp)
 
             }.onFailure {
-              _eventChannel.send(LoginEvent.LoginError(LOGIN_ERROR))
+                _eventChannel.send(LoginEvent.LoginError(LOGIN_ERROR))
             }
     }
 

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
@@ -1,8 +1,14 @@
 package com.example.issuetalk.feature.auth
 
+import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.issuetalk.core.domain.repository.auth.AuthRepository
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,13 +20,11 @@ import javax.inject.Inject
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val authRepository: AuthRepository
+
 ) : ViewModel() {
     private val _eventChannel = Channel<LoginEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
-    fun loginKakao() = viewModelScope.launch {
-
-        }
 
     fun navigateToSignUp() {
         viewModelScope.launch {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
@@ -25,12 +25,6 @@ class LoginViewModel @Inject constructor(
     private val _eventChannel = Channel<LoginEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
-    fun navigateToSignUp() {
-        viewModelScope.launch {
-            _eventChannel.send(LoginEvent.NavigateToSignUp)
-        }
-    }
-
     fun navigateToHome() {
         viewModelScope.launch {
             _eventChannel.send(LoginEvent.NavigateToHome)
@@ -42,7 +36,7 @@ class LoginViewModel @Inject constructor(
             .onSuccess {
                 verifyResitered()
             }.onFailure {
-                _eventChannel.send(LoginEvent.ShowDialog(LOGIN_ERROR))
+                _eventChannel.send(LoginEvent.LoginError(LOGIN_ERROR))
             }
     }
 
@@ -57,14 +51,14 @@ class LoginViewModel @Inject constructor(
                 _eventChannel.send(LoginEvent.NavigateToSignUp)
 
             }.onFailure {
-                _eventChannel.send(LoginEvent.ShowDialog(LOGIN_ERROR))
+              _eventChannel.send(LoginEvent.LoginError(LOGIN_ERROR))
             }
     }
 
     sealed class LoginEvent {
         data object NavigateToSignUp : LoginEvent()
         data object NavigateToHome : LoginEvent()
-        data class ShowDialog(val message: String) : LoginEvent()
+        data class LoginError(val message: String) : LoginEvent()
     }
 
     companion object {

--- a/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/LoginViewModel.kt
@@ -37,10 +37,25 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    fun loginFirebaseWithKakao(idToken: String) = viewModelScope.launch {
+      fun loginFirebaseWithKakao(idToken: String) = viewModelScope.launch {
         authRepository.loginFirebaseWithKakao(idToken)
             .onSuccess {
-                Log.d("로그인", "성공")
+                verifyResitered()
+            }.onFailure {
+                _eventChannel.send(LoginEvent.ShowDialog(LOGIN_ERROR))
+            }
+    }
+
+    private suspend fun verifyResitered() = viewModelScope.launch {
+        authRepository.verifyRegistered()
+            .onSuccess { isRegistered ->
+                if(isRegistered) {
+                    _eventChannel.send(LoginEvent.NavigateToHome)
+                    return@onSuccess
+                }
+
+                _eventChannel.send(LoginEvent.NavigateToSignUp)
+
             }.onFailure {
                 _eventChannel.send(LoginEvent.ShowDialog(LOGIN_ERROR))
             }

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpScreen.kt
@@ -1,8 +1,8 @@
 package com.example.issuetalk.feature.auth.signup
 
 
+import android.widget.Toast
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -50,6 +50,7 @@ import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -58,8 +59,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -68,7 +67,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.example.issuetalk.R
 import com.example.issuetalk.core.common.util.clickWithNoneRipple
-import com.example.issuetalk.core.common.util.clickWithRipple
 import com.example.issuetalk.core.designsystem.component.checkDialog
 import com.example.issuetalk.core.designsystem.theme.lightRed
 import com.example.issuetalk.core.designsystem.theme.primaryColor
@@ -83,19 +81,22 @@ fun SignUpRoute(
     navigateToHome: () -> Unit,
     viewModel: SignUpViewModel = hiltViewModel()
 ) {
+    val context = LocalContext.current
     val nameText by viewModel.nameText.collectAsStateWithLifecycle()
     val isNameValid by viewModel.isNameValid.collectAsStateWithLifecycle()
     val gender by viewModel.gender.collectAsStateWithLifecycle()
     val birthYear by viewModel.birthYear.collectAsStateWithLifecycle()
-
     var dialogMessage by remember { mutableStateOf<String?>(null) }
 
 
     LaunchedEffect(true) {
         viewModel.eventChannel.collect { event ->
             when (event) {
-                is SignUpViewModel.SignUpEvent.NavigateToHome -> navigateToHome()
-                is SignUpViewModel.SignUpEvent.ShowDialog -> dialogMessage = event.message
+                is SignUpViewModel.SignUpEvent.SignUpSuccess -> {
+                    navigateToHome()
+                    Toast.makeText(context,"회원가입에 성공했습니다!", Toast.LENGTH_SHORT).show()
+                }
+                is SignUpViewModel.SignUpEvent.SignUpFailure -> dialogMessage = event.message
             }
         }
     }
@@ -135,7 +136,7 @@ fun SignUpScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
     var showBottomBirthYearSheet by remember { mutableStateOf(false) }
     val bottomSheetState = rememberModalBottomSheetState()
-    val signUpAvailability = isNameValid && gender != null && birthYear.isNotEmpty()
+    val signUpAvailability = isNameValid && gender != Gender.NONE && birthYear.isNotEmpty()
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
@@ -1,8 +1,10 @@
 package com.example.issuetalk.feature.auth.signup
 
+import UserInformationRequest
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.issuetalk.core.domain.repository.auth.AuthRepository
+import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,7 +27,7 @@ class SignUpViewModel @Inject constructor(
     private val _isNameValid = MutableStateFlow(false)
     val isNameValid = _isNameValid.asStateFlow()
 
-    private val _gender : MutableStateFlow<Gender?> = MutableStateFlow(null)
+    private val _gender: MutableStateFlow<Gender> = MutableStateFlow(Gender.NONE)
     val gender = _gender.asStateFlow()
 
     private val _birthYear = MutableStateFlow("")
@@ -36,27 +38,35 @@ class SignUpViewModel @Inject constructor(
         validateName()
     }
 
-    fun setGender(gender : Gender) {
+    fun setGender(gender: Gender) {
         _gender.value = gender
     }
 
-    fun setBirthYear(birthYear : String) {
+    fun setBirthYear(birthYear: String) {
         _birthYear.value = birthYear;
     }
 
     private fun validateName() {
         val nicknameRegex = "^.{$NAME_MIN_LENGTH,$NAME_MAX_LENGTH}$".toRegex()
-         _isNameValid.value = _nameText.value.trim().matches(nicknameRegex)
+        _isNameValid.value = _nameText.value.trim().matches(nicknameRegex)
     }
 
 
     fun signUp() = viewModelScope.launch {
+        val userInformationRequest = UserInformationRequest(
+            name = _nameText.value,
+            gender = _gender.value.gender,
+            birthYear = _birthYear.value.toInt()
+        )
 
+        authRepository.setUserInformation(userInformationRequest)
+            .onSuccess { _eventChannel.send(SignUpEvent.SignUpSuccess) }
+            .onFailure { _eventChannel.send(SignUpEvent.SignUpFailure(SIGNUP_ERROR)) }
     }
 
     sealed class SignUpEvent {
-        data object  NavigateToHome : SignUpEvent()
-        data class ShowDialog(val message: String) : SignUpEvent()
+        data object SignUpSuccess : SignUpEvent()
+        data class SignUpFailure(val message: String) : SignUpEvent()
     }
 
     companion object {
@@ -66,8 +76,7 @@ class SignUpViewModel @Inject constructor(
     }
 
     enum class Gender(val gender: String) {
-      MALE("남자"), FEMALE("여자")
+        NONE("선택 안함"), MALE("남자"), FEMALE("여자")
     }
-
 
 }

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/SignUpViewModel.kt
@@ -20,7 +20,6 @@ class SignUpViewModel @Inject constructor(
     private val _eventChannel = Channel<SignUpEvent>()
     val eventChannel = _eventChannel.receiveAsFlow()
 
-
     private val _nameText = MutableStateFlow("")
     val nameText = _nameText.asStateFlow()
 
@@ -60,7 +59,10 @@ class SignUpViewModel @Inject constructor(
         )
 
         authRepository.setUserInformation(userInformationRequest)
-            .onSuccess { _eventChannel.send(SignUpEvent.SignUpSuccess) }
+            .onSuccess {
+                authRepository.saveShowHome()
+                _eventChannel.send(SignUpEvent.SignUpSuccess)
+            }
             .onFailure { _eventChannel.send(SignUpEvent.SignUpFailure(SIGNUP_ERROR)) }
     }
 

--- a/app/src/main/java/com/example/issuetalk/feature/auth/signup/component/BirthYearPicker.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/auth/signup/component/BirthYearPicker.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
@@ -46,7 +47,7 @@ fun BirthYearPicker(
     startYear : String,
     visibleItemsCount: Int = 3,
     textModifier: Modifier = Modifier,
-    textStyle: TextStyle = LocalTextStyle.current,
+//    textStyle: TextStyle = LocalTextStyle.current,
     dividerColor: Color = LocalContentColor.current,
 ) {
 
@@ -96,13 +97,14 @@ fun BirthYearPicker(
                     text = getItem(index),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
-                    style = textStyle,
+                    style = TextStyle(fontSize = 16.sp),
                     modifier = Modifier
                         .onSizeChanged { size -> itemHeightPixels.value = size.height }
                         .then(textModifier)
                 )
             }
         }
+
 
         Divider(
             color = dividerColor,

--- a/app/src/main/java/com/example/issuetalk/feature/splash/SplashScreen.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/splash/SplashScreen.kt
@@ -6,13 +6,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -20,7 +18,10 @@ import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.example.issuetalk.R
+import com.example.issuetalk.feature.auth.LoginViewModel
+import com.example.issuetalk.feature.auth.LoginViewModel.LoginEvent
 import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.delay
 
@@ -28,24 +29,27 @@ import kotlinx.coroutines.delay
  fun SplashRoute(
     navigateToLogin: () -> Unit,
     navigateToHome: () -> Unit,
+    viewModel: SplashViewModel = hiltViewModel()
 ) {
-    SplashScreen(navigateToLogin, navigateToHome)
+    LaunchedEffect(true) {
+        viewModel.checkShowHome()
+        viewModel.eventChannel.collect { event ->
+            when (event) {
+                is SplashViewModel.SplashEvent.NavigateToHome -> navigateToHome()
+                is SplashViewModel.SplashEvent.NavigateToLogin -> navigateToLogin()
+            }
+        }
+    }
+
+    SplashScreen()
 }
 
 @Composable
 fun SplashScreen(
-    navigateToLogin: () -> Unit,
-    navigateToHome: () -> Unit,
-) {
-    val auth = FirebaseAuth.getInstance()
-    val user = auth.currentUser
 
-    LaunchedEffect(true) {
-        delay(500)
-        navigateToLogin()
-//        if(user == null) navigateToLogin()
-//        else navigateToHome()
-    }
+) {
+
+
 
     Column (
         modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/example/issuetalk/feature/splash/SplashViewModel.kt
+++ b/app/src/main/java/com/example/issuetalk/feature/splash/SplashViewModel.kt
@@ -1,0 +1,31 @@
+package com.example.issuetalk.feature.splash
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.issuetalk.core.domain.repository.auth.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+    private val _eventChannel = Channel<SplashEvent>()
+    val eventChannel = _eventChannel.receiveAsFlow()
+
+     fun checkShowHome() = viewModelScope.launch {
+        val showHome = authRepository.getShowHome()
+        if(showHome) _eventChannel.send(SplashEvent.NavigateToHome)
+        else _eventChannel.send(SplashEvent.NavigateToLogin)
+    }
+
+    sealed class SplashEvent {
+        data object NavigateToLogin : SplashEvent()
+        data object NavigateToHome : SplashEvent()
+    }
+}

--- a/app/src/main/java/com/example/issuetalk/main/IssueTalkApplication.kt
+++ b/app/src/main/java/com/example/issuetalk/main/IssueTalkApplication.kt
@@ -1,11 +1,15 @@
 package com.example.issuetalk.main
 
 import android.app.Application
+import com.example.issuetalk.BuildConfig
+import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class IssueTalkApplication : Application()  {
     override fun onCreate() {
         super.onCreate()
+
+        KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
     }
 }

--- a/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
+++ b/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
@@ -29,7 +29,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        KakaoSdk.init(this, "ccecf62a10b57cf137be324f5ab43f39")
+
 
         enableEdgeToEdge()
         WindowCompat.setDecorFitsSystemWindows(window, false)

--- a/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
+++ b/app/src/main/java/com/example/issuetalk/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.example.issuetalk.main
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -17,6 +18,8 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.issuetalk.core.designsystem.theme.IssueTalkTheme
 import com.example.issuetalk.main.navigation.IssueTalkNavHost
+import com.kakao.sdk.common.KakaoSdk
+import com.kakao.sdk.common.util.Utility
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -25,6 +28,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        KakaoSdk.init(this, "ccecf62a10b57cf137be324f5ab43f39")
 
         enableEdgeToEdge()
         WindowCompat.setDecorFitsSystemWindows(window, false)

--- a/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
+++ b/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
@@ -54,7 +54,11 @@ fun IssueTalkNavHost(
                 )
             },
             navigateToHome = {
-                navController.navigateToHome()
+                navController.navigateToHome(
+                    navOptions {
+                        popUpTo<LoginRoute> { inclusive = true }
+                    }
+                )
             }
         )
         signUpScreen(

--- a/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
+++ b/app/src/main/java/com/example/issuetalk/main/navigation/IssueTalkNavHost.kt
@@ -48,17 +48,13 @@ fun IssueTalkNavHost(
         loginScreen(
             navigateToSignUp = {
                 navController.navigateToSignUp(
-//                    navOptions {
-//                        popUpTo<LoginRoute> { inclusive = true }
-//                    }
-                )
-            },
-            navigateToHome = {
-                navController.navigateToHome(
                     navOptions {
                         popUpTo<LoginRoute> { inclusive = true }
                     }
                 )
+            },
+            navigateToHome = {
+                navController.navigateToHome()
             }
         )
         signUpScreen(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,13 +5,14 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         google()
         mavenCentral()
+        maven { url = java.net.URI("https://devrepo.kakao.com/nexus/content/groups/public/") }
     }
 }
-
 rootProject.name = "IssueTalk"
 include(":app")


### PR DESCRIPTION
제목: [키워드] - 수정한 내용

### 작업 내용
- [x] 카카오 로그인 연동
- [x] Firebase OIDC 로그인(카카오) 연동 
- [x] 회원가입 - 유저 정보 저장
- [x] 스플래시 화면 전환 로직

### 참고 사항
- 현재는 둘러보기 또는 로그인을 했을 때 SharedPreference를 이용해 앱을 다시 켯을 때 바로 홈 화면으로 진입하도록 했다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Firebase 기반 카카오 로그인 통합과 향상된 회원가입 프로세스 도입 (OAuth 인증 지원 포함)
  - 회원가입 성공 시 토스트 메시지로 피드백 제공
  - 스플래시 화면과 내비게이션 로직 최적화를 통해 빠르고 원활한 화면 전환 구현
  - 새로운 로컬 인증 데이터 소스 추가로 사용자 정보 관리 기능 향상
  - Kakao SDK 초기화 기능 추가로 외부 인증 통합 개선

- **Style**
  - 일부 화면 구성 요소의 텍스트 스타일 및 레이아웃 업데이트로 가독성과 디자인 개선됨

<!-- end of auto-generated comment: release notes by coderabbit.ai -->